### PR TITLE
feat: Add IpldExploreForm so users can explore

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'redux-bundler-react'
 import navHelper from 'internal-nav-helper'
+import IpldExploreForm from './explore/IpldExploreForm'
 
 export class App extends Component {
   static propTypes = {
@@ -24,15 +25,20 @@ export class App extends Component {
     return (
       <div className='sans-serif' onClick={navHelper(this.props.doUpdateUrl)}>
         {embed ? null : (
-          <header className='flex items-center pa3 bg-navy'>
-            <a href='#/' title='home' className='w-50'>
-              <img src='https://ipfs.io/images/ipfs-logo.svg' alt='IPFS' style={{height: 50}} />
-            </a>
-            <h1 className='w-50 ma0 tr f3 fw2 montserrat aqua'>IPLD EXPLORER</h1>
+          <header className='flex-ns items-center pa3 bg-navy'>
+            <div className='flex-auto'>
+              <a href='#/' title='home' className='db dib-ns'>
+                <img src='https://ipfs.io/images/ipfs-logo.svg' alt='IPFS' style={{height: 50, width: 117.5}} />
+              </a>
+              <div className='dib ml3-ns'>
+                <IpldExploreForm />
+              </div>
+            </div>
+            <h1 className='dn db-ns ma0 tr f3 fw2 montserrat aqua'>IPLD EXPLORER</h1>
           </header>
         )}
         <div className='pt4 ph4'>
-          <Page />
+          <Page embed={embed} />
         </div>
       </div>
     )

--- a/src/bundles/explore.js
+++ b/src/bundles/explore.js
@@ -1,3 +1,4 @@
+import Cid from 'cids'
 import { createAsyncResourceBundle, createSelector } from 'redux-bundler'
 import { resolveIpldPath, quickSplitPath } from '../lib/path'
 
@@ -12,14 +13,27 @@ const bundle = createAsyncResourceBundle({
     const pathParts = quickSplitPath(path)
     if (!pathParts) return null
     const {cidOrFqdn, rest} = pathParts
-    const {targetNode, canonicalPath, localPath, nodes, pathBoundaries} = await resolveIpldPath(getIpfs, cidOrFqdn, rest)
-    return {
-      path,
-      targetNode,
-      canonicalPath,
-      localPath,
-      nodes,
-      pathBoundaries
+    try {
+      // TODO: handle ipns, which would give us a fqdn in the cid position.
+      const cid = new Cid(cidOrFqdn)
+      const {
+        targetNode,
+        canonicalPath,
+        localPath,
+        nodes,
+        pathBoundaries
+      } = await resolveIpldPath(getIpfs, cid.toBaseEncodedString(), rest)
+
+      return {
+        path,
+        targetNode,
+        canonicalPath,
+        localPath,
+        nodes,
+        pathBoundaries
+      }
+    } catch (error) {
+      return { path, error }
     }
   },
   staleAfter: Infinity,

--- a/src/explore/ExplorePage.js
+++ b/src/explore/ExplorePage.js
@@ -27,17 +27,17 @@ class ExplorePage extends React.Component {
   }
 
   render () {
-    let {explore, exploreIsLoading, explorePathFromHash} = this.props
+    let {embed, explore, exploreIsLoading, explorePathFromHash} = this.props
     if (!explorePathFromHash) {
       // No IPLD path to explore so show the intro page
-      return <StartExploringPage />
+      return <StartExploringPage embed={embed} />
     }
     // Hide the old data while we navigate to the new. We can get much fancier
     // with showing that the request is loading, but for now, this'l hide the
     // now stale info and show a loading spinner.
     explore = explore || {}
     explore = exploreIsLoading ? {} : explore
-    const {targetNode, localPath, nodes, pathBoundaries} = explore
+    const {error, targetNode, localPath, nodes, pathBoundaries} = explore
     const sourceNode = (nodes && nodes[0]) || null
     return (
       <div className='nl3 nt4'>
@@ -54,6 +54,11 @@ class ExplorePage extends React.Component {
         ) : <div style={{height: 54}} /> }
         <div className='dt-l dt--fixed'>
           <div className='dtc-l w-100 w-two-thirds-l pr3-l v-top'>
+            {error ? (
+              <div className='bg-red white pa3 lh-copy'>
+                <span className='mr2'>Path error:</span>{error.message || error}
+              </div>
+            ) : null}
             {targetNode ? (
               <ObjectInfo
                 style={{background: '#FBFBFB'}}
@@ -64,7 +69,10 @@ class ExplorePage extends React.Component {
                 data={targetNode.data}
                 type={targetNode.type}
                 onLinkClick={this.onLinkClick} />
-            ) : <ComponentLoader pastDelay /> }
+            ) : null }
+            {!error && !targetNode ? (
+              <ComponentLoader pastDelay />
+            ) : null}
           </div>
           <div className='dn dtc-l w-third-l v-top'>
             {targetNode ? (

--- a/src/explore/IpldExploreForm.js
+++ b/src/explore/IpldExploreForm.js
@@ -33,7 +33,7 @@ class IpldExploreForm extends React.Component {
 
   render () {
     return (
-      <form className='black-80 dt dt--fixed' style={{padding: '20px 40px', maxWidth: 560}} onSubmit={this.onSubmit}>
+      <form className='black-80 dt dt--fixed' style={{maxWidth: 560}} onSubmit={this.onSubmit}>
         <div className='dtc v-top'>
           <div className='relative'>
             <input id='ipfs-path' className='input-reset ba pa2 mb2 db w-100 f6 br-0 placeholder-light focus-outline' style={{borderColor: '#C6D3DA', borderRadius: '3px 0 0 3px'}} type='text' placeholder='QmHash' aria-describedby='name-desc' onChange={this.onChange} value={this.state.path} />

--- a/src/explore/StartExploringPage.js
+++ b/src/explore/StartExploringPage.js
@@ -4,6 +4,7 @@ import Box from '../components/box/Box'
 import Tooltip from '../components/tooltip/Tooltip'
 import { colorForNode, nameForNode, shortNameForNode } from './object-info/ObjectInfo'
 import ipldLogoSrc from './ipld.svg'
+import IpldExploreForm from './IpldExploreForm'
 
 const ExploreSuggestion = ({cid, name, type}) => {
   return (
@@ -21,7 +22,7 @@ const ExploreSuggestion = ({cid, name, type}) => {
   )
 }
 
-const StartExploringPage = () => {
+const StartExploringPage = ({embed}) => {
   return (
     <div>
       <Helmet>
@@ -31,7 +32,8 @@ const StartExploringPage = () => {
         <div className='db dib-l w-50-l v-top'>
           <div className='pr5-l'>
             <h1 className='fw2 montserrat'>Explore the Merkle Forest</h1>
-            <p className='lh-copy f6 charcoal-muted'>Paste a CID into the explore box above to browse the IPLD node it addresses, or click on an option below.</p>
+            <p className='lh-copy f5 charcoal-muted'>Paste a CID into box to fetch the IPLD node it addresses, or choose a featured dataset.</p>
+            {embed ? <IpldExploreForm /> : null}
             <ul className='list pl0 ma0'>
               <li>
                 <ExploreSuggestion name='The IPLD Website' cid='QmTxRvftPnKeR7iJfeVpfsGCYEwZ92ot9zrTksAWUACTs7' type='dag-pb' />


### PR DESCRIPTION
Adds a form that lets the user choose their own ipld adventure.

![screenshot 2018-07-31 14 59 23](https://user-images.githubusercontent.com/58871/43464237-759a5594-94d2-11e8-8215-4867b5cfed62.png)

Adds try/catch block around ipld resolving so we don't freak out on surprising responses. See #9 ... we now show an error message instead of hanging the browser.

![screenshot 2018-07-31 14 59 31](https://user-images.githubusercontent.com/58871/43464247-812c1014-94d2-11e8-9fcb-dccf7983a4ba.png)


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>