### PR TITLE
fix: use ipld-dag-pb from git to get git support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10530,9 +10530,8 @@
       }
     },
     "ipld-dag-pb": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.5.tgz",
-      "integrity": "sha512-HHKqyjP1m9PxbT1+EWrbq/dH6uIY90mvwQ6G79JWKsdCsyOvRbyCdmZmXbbuTN9JBFcoMG2684qix+HtiEz0fQ==",
+      "version": "github:ipld/js-ipld-dag-pb#4c701aa334307f514d4253763b0e2a990adae40f",
+      "from": "github:ipld/js-ipld-dag-pb#4c701aa334307f514d4253763b0e2a990adae40f",
       "requires": {
         "async": "^2.6.1",
         "bs58": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ipfs-redux-bundle": "^1.0.0",
     "ipfs-unixfs": "^0.1.15",
     "ipld": "^0.17.3",
-    "ipld-dag-pb": "^0.14.5",
+    "ipld-dag-pb": "github:ipld/js-ipld-dag-pb#4c701aa334307f514d4253763b0e2a990adae40f",
     "is-ipfs": "^0.3.2",
     "milliseconds": "^1.0.3",
     "multiaddr": "^5.0.0",

--- a/src/bundles/explore.js
+++ b/src/bundles/explore.js
@@ -33,6 +33,7 @@ const bundle = createAsyncResourceBundle({
         pathBoundaries
       }
     } catch (error) {
+      console.log('Failed to resolve path', path, error)
       return { path, error }
     }
   },


### PR DESCRIPTION
Pull in js-ipld-dag-pb from git so we get this fix https://github.com/ipld/js-ipld-dag-pb/pull/80 and suport for traversing through git objects ✨ 🎷 🐩 

Fixes #9 

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>