### PR TITLE
fix: tweaks to fix layout and url parsing when embedded

### DIFF
--- a/src/bundles/explore.js
+++ b/src/bundles/explore.js
@@ -46,8 +46,8 @@ bundle.selectExplorePathFromHash = createSelector(
   'selectRouteInfo',
   (routeInfo) => {
     if (!routeInfo.url.startsWith('/explore')) return
-    if (!routeInfo.params.path) return
-    return decodeURIComponent(routeInfo.params.path)
+    const path = routeInfo.url.slice('/explore'.length)
+    return decodeURIComponent(path)
   }
 )
 

--- a/src/components/ExplorePage.js
+++ b/src/components/ExplorePage.js
@@ -52,7 +52,6 @@ class ExplorePage extends React.Component {
         {pathBoundaries && targetNode ? (
           <GraphCrumb
             style={{padding: '15px 0 10px'}}
-            className='ml4'
             cid={sourceNode.cid}
             pathBoundaries={pathBoundaries}
             localPath={localPath} />

--- a/src/components/StartExploringPage.js
+++ b/src/components/StartExploringPage.js
@@ -25,7 +25,7 @@ const StartExploringPage = ({embed}) => {
       <Helmet>
         <title>Explore - IPLD</title>
       </Helmet>
-      <div className='flex-l pl4-l'>
+      <div className='flex-l'>
         <div className='flex-none mr3-l'>
           <div className='measure-l'>
             <div className='pl3 pl0-l pt4 pt2-l'>


### PR DESCRIPTION
In Web UI the addtional padding is inconsistent with the
other pages, so we remove it.

Fix decoding ipld path from url hash so that it leaves the
intial slash on the path, to fix /ipfs/* style address
resolving.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>