### PR TITLE
fix: load locales via relative path

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -20,6 +20,10 @@ i18n
     ns: ['explore'],
     fallbackLng: 'en',
     debug: process.env.NODE_ENV !== 'production',
+    backend: {
+      // ensure a realtive path is used to look up the locales, so it works when used from /ipfs/<cid>
+      loadPath: 'locales/{{lng}}/{{ns}}.json'
+    },
     // react i18next special options (optional)
     react: {
       wait: true,


### PR DESCRIPTION
otherwise they fail when loaded from an /ipfs or /ipns mounted path

fixes #38 

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>