### PR TITLE
fix(ci): update circle build for cluster 0.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
   deploy:
     docker:
-      - image: olizilla/ipfs-dns-deploy:1.1
+      - image: olizilla/ipfs-dns-deploy:latest
         environment:
           DOMAIN: explore.ipld.io
           BUILD_DIR: build


### PR DESCRIPTION
Right now website does not deploy ([error](https://circleci.com/gh/ipfs-shipyard/ipld-explorer/60)), because `ipfs-dns-deploy:1.1` is not compatible with cluster 0.10. Switching to `latest` solves current and future problems like this one. 