### PR TITLE
feat: add link to sources

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -14,9 +14,17 @@ const Header = ({ t }) => {
           <IpldExploreForm />
         </div>
       </div>
-      <h1 className='pt2 pt0-l ma0 f3 fw2 montserrat aqua ttu flex-none'>
-        { t('appName') }
-      </h1>
+      <div className='pt2 pt0-l ma0 inline-flex items-center'>
+        <h1 className='f3 fw2 montserrat aqua ttu'>{ t('appName') }</h1>
+        <div className='pl3'>
+          <a href='https://github.com/ipfs-shipyard/ipld-explorer' target='_blank' aria-label='View source on GitHub'>
+            <svg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 32.58 31.77'>
+              <path fill='#7f8491' d='M16.29 0a16.29 16.29 0 00-5.15 31.75c.82.15 1.11-.36 1.11-.79v-2.77C7.7 29.18 6.74 26 6.74 26a4.36 4.36 0 00-1.81-2.39c-1.47-1 .12-1 .12-1a3.43 3.43 0 012.49 1.68 3.48 3.48 0 004.74 1.36 3.46 3.46 0 011-2.18c-3.62-.41-7.42-1.81-7.42-8a6.3 6.3 0 011.67-4.37 5.94 5.94 0 01.16-4.31s1.37-.44 4.48 1.67a15.41 15.41 0 018.16 0c3.11-2.11 4.47-1.67 4.47-1.67a5.91 5.91 0 01.2 4.28 6.3 6.3 0 011.67 4.37c0 6.26-3.81 7.63-7.44 8a3.85 3.85 0 011.11 3v4.47c0 .53.29.94 1.12.78A16.29 16.29 0 0016.29 0z'/>
+            </svg>
+          </a>
+        </div>
+      </div>
+
     </header>
   )
 }

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -17,7 +17,7 @@ const Header = ({ t }) => {
       <div className='pt2 pt0-l ma0 inline-flex items-center'>
         <h1 className='f3 fw2 montserrat aqua ttu'>{ t('appName') }</h1>
         <div className='pl3'>
-          <a href='https://github.com/ipfs-shipyard/ipld-explorer' target='_blank' aria-label='View source on GitHub'>
+          <a href='https://github.com/ipfs-shipyard/ipld-explorer' target='_blank' rel="noopener noreferrer" aria-label='View source on GitHub'>
             <svg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 32.58 31.77'>
               <path fill='#7f8491' d='M16.29 0a16.29 16.29 0 00-5.15 31.75c.82.15 1.11-.36 1.11-.79v-2.77C7.7 29.18 6.74 26 6.74 26a4.36 4.36 0 00-1.81-2.39c-1.47-1 .12-1 .12-1a3.43 3.43 0 012.49 1.68 3.48 3.48 0 004.74 1.36 3.46 3.46 0 011-2.18c-3.62-.41-7.42-1.81-7.42-8a6.3 6.3 0 011.67-4.37 5.94 5.94 0 01.16-4.31s1.37-.44 4.48 1.67a15.41 15.41 0 018.16 0c3.11-2.11 4.47-1.67 4.47-1.67a5.91 5.91 0 01.2 4.28 6.3 6.3 0 011.67 4.37c0 6.26-3.81 7.63-7.44 8a3.85 3.85 0 011.11 3v4.47c0 .53.29.94 1.12.78A16.29 16.29 0 0016.29 0z'/>
             </svg>


### PR DESCRIPTION
Adds svg GitHub logo link (in header to avoid repo conflict when IPLD Explorer is displayed inside Desktop).
Closes https://github.com/ipfs-shipyard/ipld-explorer/issues/24.

Desktop
![image](https://user-images.githubusercontent.com/1507828/82701692-e5bc3680-9c2d-11ea-8da5-1df3f68a28c0.png)

Mobile
![image](https://user-images.githubusercontent.com/1507828/82701738-f79dd980-9c2d-11ea-8397-f65a9c380460.png)
